### PR TITLE
init zita-convolver in multithread mode to reduce xruns

### DIFF
--- a/convolution.cc
+++ b/convolution.cc
@@ -39,6 +39,7 @@
 #include <math.h>
 #include <string.h>
 #include <stdint.h>
+#include <sched.h>
 #include <pthread.h>
 #include <assert.h>
 
@@ -378,7 +379,7 @@ int clv_initialize (
 				/*max-convolution length */ max_size,
 				/*quantum*/  buffersize,
 				/*min-part*/ buffersize /* must be >= fragm */,
-				/*max-part*/ buffersize /* Convproc::MAXPART -> stich output every period */
+				/*max-part* buffersize */ Convproc::MAXPART /*-> stich output every period */
 				)) {
 		fprintf (stderr, "convoLV2: Cannot initialize convolution engine.\n");
 		goto errout;
@@ -477,7 +478,7 @@ int clv_initialize (
 	clv->convproc->print (stderr);
 #endif
 
-	if (clv->convproc->start_process (0, 0)) {
+	if (clv->convproc->start_process (0, SCHED_FIFO)) {
 		fprintf(stderr, "convoLV2: Cannot start processing.\n");
 		goto errout;
 	}
@@ -554,7 +555,7 @@ int clv_convolve (LV2convolv *clv,
 	}
 #endif
 
-	int f = clv->convproc->process (false);
+	int f = clv->convproc->process (true);
 
 	if (f /*&Convproc::FL_LOAD)*/ ) {
 		/* Note this will actually never happen in sync-mode */


### PR DESCRIPTION
Hi,

I noticed when using convoLV2 I would encounter xruns pretty quick after only having a few instances open. I compared the code with ir.lv2 ( https://github.com/tomszilagyi/ir.lv2 ) and realized the main difference is convoLV2 is it is being started in single thread (batch) mode.

These PR changes give it a performance much more comparable to ir.lv2.